### PR TITLE
Fix code scanning alert no. 2: Overly permissive regular expression range

### DIFF
--- a/test/fixtures/clean-snapshot.js
+++ b/test/fixtures/clean-snapshot.js
@@ -7,7 +7,7 @@ const cleanNewlines = (s) => s.replace(/\r\n/g, '\n')
 // ideally this could be avoided but its easier to just
 // run this command inside cleanSnapshot
 const normalizePath = (str) => cleanNewlines(str)
-  .replace(/[A-z]:\\/g, '\\') // turn windows roots to posix ones
+  .replace(/[A-Za-z]:\\/g, '\\') // turn windows roots to posix ones
   .replace(/\\+/g, '/') // replace \ with /
 
 const pathRegex = (p) => new RegExp(normalizePath(p), 'gi')


### PR DESCRIPTION
Fixes [https://github.com/aka1976/cli/security/code-scanning/2](https://github.com/aka1976/cli/security/code-scanning/2)

To fix the problem, we need to replace the overly permissive range `[A-z]` with a more precise range that matches only uppercase and lowercase letters. The correct ranges are `[A-Z]` for uppercase letters and `[a-z]` for lowercase letters. We can combine these ranges into a single character class `[A-Za-z]`.

- Update the regular expression on line 10 to use `[A-Za-z]` instead of `[A-z]`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
